### PR TITLE
CC-16902 Backport for added additional validation to form fields.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "spryker/category": "^4.21.0 || ^5.0.0",
         "spryker/currency": "^3.0.0",
         "spryker/decimal-object": "^1.0.0",
+        "spryker/gui": "^3.48.0",
         "spryker/gui-table": "^1.8.0",
         "spryker/kernel": "^3.51.0",
         "spryker/laminas": "^1.0.0",

--- a/dependency.json
+++ b/dependency.json
@@ -1,5 +1,6 @@
 {
     "include": {
+        "spryker/gui": "Provides `sanitize_xss` functionality.",
         "spryker/merchant-product-approval": "Makes sure the connection between Merchant and ProductApproval exist.",
         "spryker/zed-ui": "Zed UI provides layout templates and frontend infrastructure.",
         "spryker/transfer": "Provides transfer objects definition with `::get*OrFail()` functionality."

--- a/src/Spryker/Zed/ProductMerchantPortalGui/Communication/Form/Type/ProductImageFormType.php
+++ b/src/Spryker/Zed/ProductMerchantPortalGui/Communication/Form/Type/ProductImageFormType.php
@@ -126,6 +126,7 @@ class ProductImageFormType extends AbstractType
             ],
             'label' => static::LABEL_SMALL_IMAGE_URL,
             'required' => true,
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -144,6 +145,7 @@ class ProductImageFormType extends AbstractType
             ],
             'label' => static::LABEL_LARGE_IMAGE_URL,
             'required' => true,
+            'sanitize_xss' => true,
         ]);
 
         return $this;


### PR DESCRIPTION
- Branch: backport/2.15.0
- Ticket: https://spryker.atlassian.net/browse/CC-16902
- Version: 2.15.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductMerchantPortalGui           | minor                 | Gui                   |
   
-----------------------------------------

#### Module ProductMerchantPortalGui

##### Change log

Fixes

- Adjusted  `ProductImageFormType` to sanitize `externalUrlSmall` and `externalUrlLarge` fields.
- Impacted `UpdateProductAbstractController::indexAction()` with these changes.
- Impacted `UpdateProductConcreteController::indexAction()` with these changes.
- Added `Gui` module to dependencies.